### PR TITLE
Update instructions RN < 0.40

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,11 +44,17 @@ react-native-fbads [![npm version](https://badge.fury.io/js/react-native-fbads.s
 ## Installation
 
 ### 1. Install Javascript packages
-
+##### RN >= 0.40
 Install JavaScript packages:
 
 ```bash
 $ react-native install react-native-fbads
+```
+##### RN < 0.40
+Install JavaScript packages:
+
+```bash
+$ react-native install react-native-fbads@3.1.1
 ```
 
 ### 2. Configure native projects


### PR DESCRIPTION
Since RN starting from 0.40 has introduced a different way to declare imports, only 3.1.1 version and older will work.